### PR TITLE
Ignore own actions (closes #21)

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -11,6 +11,7 @@
 const urlJoin = require('url-join')
 
 const commentBodies = require('./commentBodies')
+const utils = require('./utils')
 
 // Dry actions
 
@@ -78,7 +79,7 @@ async function prStatus (prowl) {
           sha: pr.head.sha,
           state: 'success',
           description: 'Prowl approves this PR for merge',
-          context: 'prowl/merge'
+          context: utils.ownContext('merge')
         })
       )
     },

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,0 +1,5 @@
+const APP_NAME = 'prowl'
+
+module.exports = {
+  APP_NAME
+}

--- a/src/events.js
+++ b/src/events.js
@@ -9,9 +9,11 @@
  *   - forwarding to a logical handler
  */
 
+const constants = require('./constants')
 const withConfig = require('./middleware/config')
 const withLog = require('./middleware/log')
 const logic = require('./logic')
+const utils = require('./utils')
 
 const issueComment = async prowl => {
   const { context } = prowl
@@ -23,7 +25,7 @@ const issueComment = async prowl => {
     const command = args.shift()
     const subcommand = args.shift()
 
-    if (command === 'prowl' && subcommand) {
+    if (command === constants.APP_NAME && subcommand) {
       // if this is a prowl trigger
       // get the current pr
       const { data: pr } = await context.github.pullRequests.get(
@@ -87,7 +89,7 @@ const status = async prowl => {
   const { state, sha, repository } = context.payload
   const repo = repository.full_name
 
-  if (state === 'success' && !context.payload.context.startsWith('prowl')) {
+  if (state === 'success' && !utils.isOwnContext(context.payload.context)) {
     // if the status update was a success
     // search for PRs containing the commit
     const q = `${sha} repo:${repo} type:pr`

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,12 +1,24 @@
 const pj = require('../package.json')
 
+const constants = require('./constants')
+
 const { version } = pj
+
+function isOwnContext (context) {
+  return context.split('/')[0] === constants.APP_NAME
+}
+
+function ownContext (s) {
+  return [constants.APP_NAME, s].join('/')
+}
 
 function sleep (ms) {
   return new Promise(resolve => setTimeout(resolve, ms))
 }
 
 module.exports = {
+  isOwnContext,
+  ownContext,
   sleep,
   version
 }

--- a/test/integration/action.test.js
+++ b/test/integration/action.test.js
@@ -3,7 +3,7 @@ const {mockRobot, mockGithub, mockApi} = require('./utils')
 const getContentConfig = require('./api/getContentConfig')
 const statusSuccess = require('./payloads/statusSuccess')
 
-describe('stale PR', () => {
+describe('action configuration', () => {
   let robot
   let github
 

--- a/test/integration/api/getCombinedStatusForRef.json
+++ b/test/integration/api/getCombinedStatusForRef.json
@@ -1,5 +1,23 @@
 {
   "data": {
-    "state": "success"
+    "state": "failure",
+    "statuses": [
+      {
+        "state": "success",
+        "description": "Build has completed successfully",
+        "context": "continuous-integration/jenkins",
+        "creator": {
+          "login": "octocat"
+        }
+      },
+      {
+        "state": "failure",
+        "description": "Prowl cannot approve this PR yet",
+        "context": "prowl/merge",
+        "creator": {
+          "login": "octocat"
+        }
+      }
+    ]
   }
 }

--- a/test/integration/merge_method.test.js
+++ b/test/integration/merge_method.test.js
@@ -3,7 +3,7 @@ const {mockRobot, mockGithub, mockApi} = require('./utils')
 const getContentConfig = require('./api/getContentConfig')
 const statusSuccess = require('./payloads/statusSuccess')
 
-describe('stale PR', () => {
+describe('merge method configuration', () => {
   let robot
   let github
 

--- a/test/integration/status.test.js
+++ b/test/integration/status.test.js
@@ -21,16 +21,23 @@ describe('stale PR', () => {
     })
     it('failure does not trigger issues search', async () => {
       // Trigger bad event payload
-      const statusFailure = cloneDeep(statusSuccess)
-      statusFailure.payload.state = 'failure'
-      await robot.receive(statusFailure)
+      const status = cloneDeep(statusSuccess)
+      status.payload.state = 'failure'
+      await robot.receive(status)
       expect(github.search.issues).toHaveBeenCalledTimes(0)
     })
     it('pending does not trigger issues search', async () => {
       // Trigger bad event payload
-      const statusPending = cloneDeep(statusSuccess)
-      statusPending.payload.state = 'pending'
-      await robot.receive(statusPending)
+      const status = cloneDeep(statusSuccess)
+      status.payload.state = 'pending'
+      await robot.receive(status)
+      expect(github.search.issues).toHaveBeenCalledTimes(0)
+    })
+    it('prowl/ namespace status does not trigger issues search', async () => {
+      // Trigger bad event payload
+      const status = cloneDeep(statusSuccess)
+      status.payload.context = 'prowl/spam'
+      await robot.receive(status)
       expect(github.search.issues).toHaveBeenCalledTimes(0)
     })
   })

--- a/test/integration/unreadyPr.test.js
+++ b/test/integration/unreadyPr.test.js
@@ -69,7 +69,8 @@ describe('PR merge conditions', () => {
     it('PR with non success HEAD', async () => {
       // Waiting on CI
       const status = cloneDeep(getCombinedStatusForRef)
-      status.data.state = 'pending'
+      status.data.statuses[0].state = 'pending'
+      status.data.statuses[0].context = 'custom-test-status'
       github.repos.getCombinedStatusForRef = mockApi(status)
       robot = mockRobot(github)
 


### PR DESCRIPTION
- refactored how we check status namespacing
- calculate own combinedStatusForRef ignoring prowl statuses