### PR TITLE
Reviewer count

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,9 @@ targets:
       reviewers:
         - tommilligan
         - octocat  
+      # number of reviewers from the group whose approval is required
+      # default: 1
+      reviewer_count: 2
 
       # action (currently merge|status)
       # if set to 'status', set this as a required status check on your protected branch

--- a/src/commentBodies.js
+++ b/src/commentBodies.js
@@ -24,7 +24,7 @@ ${advice}`
 const error = o => commentWithJSON(`An event was not processed due to the following error:`, o)
 const mergeUnready = conditions => conditions.reduce(
   (ls, c) => `${ls}\n- ${c.description}`,
-  'This PR is not ready for merge, due to the following reasons:'
+  'This PR is not ready for merge:'
 )
 const pounceStatus = o => commentWithJSON(`Status of this PR:`, o)
 

--- a/src/logic.js
+++ b/src/logic.js
@@ -94,9 +94,9 @@ const prPounceStatus = async prowl => {
   const description = unapprovedGroups.reduce(
     (desc, group) => {
       const descReviewers = group.reviewers.reduce((rs, reviewer) => `${rs}\n    - ${reviewer}`, '')
-      return `${desc}\n  - ${group.id}${descReviewers}`
+      return `${desc}\n  - ${group.id} *(${group.count} required)*${descReviewers}`
     },
-    'This PR requires more reviews. At least one person from each group is required:'
+    'This PR requires more reviews:'
   )
   conditions.push({
     description,

--- a/src/logic.js
+++ b/src/logic.js
@@ -80,11 +80,16 @@ const prPounceStatus = async prowl => {
     approvedReviewers.push(pr.user.login)
   }
   // check this generated list against configuration
+  // for each group
   const unapprovedGroups = config.reviewerGroups.filter(reviewerGroup => {
-    return !reviewerGroup.reviewers.some(reviewer => {
+    // find matching approved reviewers
+    const approvers = reviewerGroup.reviewers.filter(reviewer => {
       return approvedReviewers.includes(reviewer)
     })
+    // return any groups that do not meet the reviewer criteria
+    return approvers.length < reviewerGroup.count
   })
+  // only approved if we have no outstanding groups to approve
   const approved = unapprovedGroups.length === 0
   const description = unapprovedGroups.reduce(
     (desc, group) => {

--- a/src/middleware/config.js
+++ b/src/middleware/config.js
@@ -55,7 +55,7 @@ function summariseTargets (targets) {
       })
       .map(target => {
         return {
-          count: target.pounce.reviewer_count || 1,
+          count: target.pounce.reviewer_count !== undefined ? target.pounce.reviewer_count : 0,
           id: target.id,
           reviewers: target.pounce.reviewers
         }

--- a/src/middleware/config.js
+++ b/src/middleware/config.js
@@ -55,6 +55,7 @@ function summariseTargets (targets) {
       })
       .map(target => {
         return {
+          count: target.pounce.reviewer_count || 1,
           id: target.id,
           reviewers: target.pounce.reviewers
         }

--- a/src/middleware/config.js
+++ b/src/middleware/config.js
@@ -55,7 +55,7 @@ function summariseTargets (targets) {
       })
       .map(target => {
         return {
-          count: target.pounce.reviewer_count !== undefined ? target.pounce.reviewer_count : 0,
+          count: target.pounce.reviewer_count !== undefined ? target.pounce.reviewer_count : 1,
           id: target.id,
           reviewers: target.pounce.reviewers
         }


### PR DESCRIPTION
Add optional configuration for setting a minimum number of required reviewers from each group.

Counts are contained within each target group. For instance, if a PR matched two groups, with each requiring two reviews, these groups will be processed independently.